### PR TITLE
Comments and undef

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl extension XML::FromPerl.
 
+0.02  ????
+    - Support creating comments with a node type of '!--'
+    - Skip `undef` entries with a warning
+
 0.01  Mon Jul 17 15:55:48 2017
 	- original version; created by h2xs 1.23 with options
 		-AXn XML::FromPerl

--- a/MANIFEST
+++ b/MANIFEST
@@ -8,3 +8,5 @@ README
 t/00_load.t
 t/01_basic.t
 t/02_tie.t
+t/03_undef.t
+t/04_comment.t

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,14 +14,26 @@ my %opts =  (  NAME          => 'XML::FromPerl',
                LICENSE       => 'perl',
 
                CONFIGURE_REQUIRES => {
-                   'ExtUtils::MakeMaker' => '0',
-                   'File::Spec' => '0',
+                    'ExtUtils::MakeMaker' => '0',
+                    'File::Spec' => '0',
                },
 
                TEST_REQUIRES => {
-                   'Test::More' => '0',
-                   'Test::Warn' => '0',
-                   'Tie::IxHash' => '0',
+                    'Test::More' => '0',
+                    'Test::Warn' => '0',
+                    'Tie::IxHash' => '0',
+               },
+
+               PREREQ_PM => {
+                    'if' => '0',
+                    'Exporter' => '0',
+                    'Import::Into' => '1.002004',
+                    'parent' => '0',
+                    'strict' => '0',
+                    'vars' => '0',
+                    'warnings' => '0',
+                    'warnings::register' => '0',
+                    'XML::LibXML' => '0',
                },
 
                META_MERGE    => {

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,6 +20,7 @@ my %opts =  (  NAME          => 'XML::FromPerl',
 
                TEST_REQUIRES => {
                    'Test::More' => '0',
+                   'Test::Warn' => '0',
                    'Tie::IxHash' => '0',
                },
 

--- a/lib/XML/FromPerl.pm
+++ b/lib/XML/FromPerl.pm
@@ -4,6 +4,7 @@ our $VERSION = '0.01';
 
 use strict;
 use warnings;
+use warnings::register qw(undefined);
 
 use XML::LibXML;
 
@@ -12,38 +13,96 @@ our @ISA = qw(Exporter);
 
 our @EXPORT_OK = qw(xml_from_perl xml_node_from_perl);
 
-sub xml_node_from_perl {
-    my $doc = shift;
-    my $data = shift;
+# Fill in the children of the given node from the passed value.
+# No return value.
+sub _fill_node_children {
+    my ($doc, $parent, $data) = @_;
+    unless(defined $data) {
+        warnings::warn(__PACKAGE__ . '::undefined',
+            "I can't create an XML node from undefined data")
+                if warnings::enabled(__PACKAGE__) &&
+                    warnings::enabled(__PACKAGE__ . '::undefined');
+        return undef;
+    }
 
-    if (ref $data eq 'ARRAY') {
-        my $e = $doc->createElement($data->[0]);
-        my $one = $data->[1];
-        my $has_attrs = ref $one eq 'HASH';
+    my ($one, $has_attrs);
+    if(ref $data eq 'ARRAY') {
+        $one = $data->[1];
+        $has_attrs = ref $one eq 'HASH';
+    }
+
+    my $new_node;
+    if (ref $data eq 'ARRAY' && $data->[0] eq '!--') {      # Comment
+        my $separ = defined $, ? $, : ' ';
+
+        # Grab the plain text nodes and paste them together.
+        my $text = join $separ,
+            map { $data->[$_] }
+            grep { defined $data->[$_] and not ref $data->[$_] }
+                (($has_attrs ? 2 : 1) .. $#$data);
+
+        $new_node = $doc->createComment($text);
+
+    } elsif (ref $data eq 'ARRAY') {                        # Regular node
+        $new_node = $doc->createElement($data->[0]);
+
         if ($has_attrs) {
             my @keys = keys %$one;
             @keys = sort @keys unless tied %$one;
             for (@keys) {
                 if (defined (my $v = $one->{$_})) {
-                    $e->setAttribute($_, $v);
+                    $new_node->setAttribute($_, $v);
                 }
             }
         }
-        $e->appendChild(xml_node_from_perl($doc, $data->[$_]))
-            for (($has_attrs ? 2 : 1) .. $#$data);
 
-        return $e;
+        _fill_node_children($doc, $new_node, $data->[$_])
+            for grep { defined $data->[$_] } (($has_attrs ? 2 : 1) .. $#$data);
+
+    } else {                                                # Text node
+        $new_node = $doc->createTextNode("$data");
     }
-    $doc->createTextNode("$data");
-}
+
+    $parent->appendChild($new_node);
+    return undef;
+} #_fill_node_children
+
+# Create a phony element we can use as a temporary parent node
+sub _create_phony {
+    my $doc = shift;
+    return $doc->createElementNS('https://metacpan.org/pod/XML::FromPerl',
+                                    'phony_root');
+} #_create_phony
+
+sub xml_node_from_perl {
+    my $doc = shift;
+    my $data = shift;
+    my $parent;
+
+    $parent = _create_phony($doc);
+    _fill_node_children $doc, $parent, $data;
+    return $parent->firstChild;
+} #xml_node_from_perl
 
 sub xml_from_perl {
     my $data = shift;
     my $doc = XML::LibXML::Document->new(@_);
-    my $root = xml_node_from_perl($doc, $data);
-    $doc->setDocumentElement($root);
-    $doc
-}
+
+    unless(defined $data) {
+        warnings::warn(__PACKAGE__ . '::undefined',
+            "I can't create an XML document from undefined data")
+                if warnings::enabled(__PACKAGE__) &&
+                    warnings::enabled(__PACKAGE__ . '::undefined');
+        return $doc;
+    }
+
+    my $parent = _create_phony($doc);
+    $doc->setDocumentElement($parent);
+    _fill_node_children $doc, $parent, $data;
+
+    $doc->setDocumentElement($parent->firstChild);
+    return $doc;
+} #xml_from_perl
 
 1;
 __END__
@@ -59,12 +118,19 @@ XML::FromPerl - Generate XML from simple Perl data structures
   my $doc = xml_from_perl
     [ Foo => { attr1 => val1, attr2 => val2},
       [ Bar => { attr3 => val3, ... },
-      [ Bar => { ... },
-      "Some Text here",
-      [Doz => { ... },
-        [ Bar => { ... }, [ ... ] ] ];
+        [ '!--', 'some comment, indicated by tag name "!--"' ],
+        [ Bar => { ... },
+        "Some Text here",
+        [Doz => { ... },
+          [ Bar => { ... }, [ ... ] ] ] ] ] ];
 
   $doc->toFile("foo.xml");
+  # ->  <Foo attr1="val1" attr2="val2">
+  #         <Bar attr3="val3">
+  #             <!--some comment...-->
+  #             ...
+  #         </Bar>
+  #     </Foo>
 
 =head1 DESCRIPTION
 
@@ -75,31 +141,36 @@ XML nodes are declared as arrays where the first slot is the tag name,
 the second is a HASH containing tag attributes and the rest are its
 children. Perl scalars are used for text sections.
 
-=head2 EXPORTABLE FUNCTIONS
+=head1 EXPORTABLE FUNCTIONS
 
-=over 4
-
-=item xml_from_perl $data
+=head2 xml_from_perl $data
 
 Converts the given perl data structure into a L<XML::LibXML::Document>
 object.
 
-=item xml_node_from_perl $doc, $data
+If C<$data> is undefined, the document will have no root element
+or other contents.
+A warning in category C<'XML::FromPerl::undefined'> will be issued.
+
+=head2 xml_node_from_perl $doc, $data
 
 Converts the given perl data structure into a L<XML::LibXML::Node>
 object linked to the document passed.
 
-=back
+If C<$data> is undefined, or is an arrayref including any undefined
+entries, the undefined entries will be ignored.
+A warning in category C<'XML::FromPerl::undefined'> will be issued for
+each C<undef> item processed.
 
-=head2 NOTES
+=head1 NOTES
 
-=head3 Namespaces
+=head2 Namespaces
 
 I have not made my mind yet about how to handle XML namespaces other
 than stating them explicitly in the names or setting the C<xmlns>
 attribute.
 
-=head3 Attribute order
+=head2 Attribute order
 
 If attribute order is important to you, declare then using
 L<Tie::IxHash>:
@@ -117,7 +188,7 @@ For instance:
 
 Otherwise attributes are sorted in lexicographical order.
 
-=head3 Memory usage
+=head2 Memory usage
 
 This module is not very memory efficient. At some point it is going to
 keep in memory both the original perl data structure and the
@@ -125,6 +196,37 @@ XML::LibXML one.
 
 Anyway, nowadays that shouldn't be a problem unless your data is
 really huge.
+
+=head2 Comments
+
+Any attributes or children of a comment node will be ignored.
+So, for example,
+
+    [ '!--',
+        { attr => 'val' },
+        [ Foo => { attr => "hello" } ]
+    ]
+
+will produce
+
+    <!---->
+
+not
+
+    <!--<Foo attr="hello"/>-->
+
+This is due to a limitation of L<XML::LibXML>:
+C<XML::LibXML::Comment::appendChild()> is a no-op.
+
+Any text elements in a comment node will be joined together by the
+value of C<$,>, or a single space if C<$,> is undefined.  For example,
+if C<$, eq '#'>,
+
+    [ '!--', qw(hello there world) ]
+
+will produce
+
+    <!--hello#there#world-->
 
 =head1 SEE ALSO
 
@@ -138,7 +240,9 @@ L<http://www.perlmonks.org/?node_id=1195009>.
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2017 by Salvador FandiE<ntilde>o E<lt>sfandino@yahoo.comE<gt>
+Copyright (C) 2017, 2019 by
+Salvador FandiE<ntilde>o E<lt>sfandino@yahoo.comE<gt> and
+Christopher White E<lt>cxw@cpan.orgE<gt>.
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself, either Perl version 5.24.1 or,

--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -1,11 +1,11 @@
 #!perl
 
 use strict;
-use warnings;
 use XML::LibXML;
 
 use XML::FromPerl qw(xml_from_perl xml_node_from_perl);
 use Test::More;
+use warnings;
 
 sub testname {
     my (undef, undef, $line) = caller;

--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -2,6 +2,8 @@
 
 use strict;
 use warnings;
+use XML::LibXML;
+
 use XML::FromPerl qw(xml_from_perl xml_node_from_perl);
 use Test::More;
 
@@ -9,6 +11,8 @@ sub testname {
     my (undef, undef, $line) = caller;
     "(line $line)"
 }
+
+# === xml_from_perl ===
 
 # Example from the perldoc, modified
 my $doc = xml_from_perl
@@ -103,5 +107,11 @@ is $child->nodeName, 'yep', testname;
 
 $child = $child->nextSibling;
 is $child->textContent, "bye!", testname;
+
+# === xml_node_from_perl ===
+
+$doc = XML::LibXML::Document->new;
+my $el = xml_node_from_perl($doc, [ Foo => {attr=>42}, '1337' ]);
+is $el->toString, '<Foo attr="42">1337</Foo>', testname;
 
 done_testing;

--- a/t/02_tie.t
+++ b/t/02_tie.t
@@ -1,10 +1,10 @@
 #!perl
 
 use strict;
-use warnings;
 use XML::FromPerl qw(xml_from_perl);
 use Test::More;
 use Tie::IxHash;
+use warnings;
 
 sub testname {
     my (undef, undef, $line) = caller;

--- a/t/03_undef.t
+++ b/t/03_undef.t
@@ -1,0 +1,63 @@
+#!perl
+
+use strict;
+use warnings;
+use XML::LibXML;
+use XML::FromPerl qw(xml_from_perl xml_node_from_perl);
+use Test::More;
+use Test::Warn;
+use Tie::IxHash;
+
+my $doc = xml_from_perl
+    [ Foo =>
+        [ Bar =>
+            undef,
+            'Baz',
+            undef,
+            'Quux',
+        ]
+    ];
+
+like $doc->toString, qr{<Foo><Bar>BazQuux</Bar></Foo>},
+    'undef element is skipped';
+    # like(), not is(), because there's also an XML processing instruction.
+
+$doc = xml_from_perl undef;
+ok $doc, 'undef in -> document out';
+ok !defined $doc->documentElement, 'undef in -> no documentElement out';
+
+warning_like { xml_from_perl undef } qr/document.*undefined/,
+    'xml_from_perl(undef) warns by default';
+
+{
+    no warnings 'XML::FromPerl::undefined';
+    warning_is { xml_from_perl undef } undef,
+        'XML::FromPerl::undefined warning category works';
+}
+
+{
+    no warnings 'XML::FromPerl';
+    warning_is { xml_from_perl undef } undef,
+        'XML::FromPerl warning category works';
+}
+
+$doc = XML::LibXML::Document->new;
+warning_like { xml_node_from_perl $doc, undef } qr/node.*undefined/,
+    'xml_node_from_perl(undef) warns by default';
+
+{
+    no warnings 'XML::FromPerl::undefined';
+    warning_is { xml_node_from_perl $doc, undef } undef,
+        'XML::FromPerl::undefined warning category works in xml_node_from_perl';
+}
+
+{
+    no warnings 'XML::FromPerl';
+    warning_is { xml_node_from_perl $doc, undef } undef,
+        'XML::FromPerl warning category works in xml_node_from_perl';
+}
+
+$doc = XML::LibXML::Document->new;
+my $el = xml_node_from_perl($doc, undef);
+ok !defined $el, 'No data -> undefined node';
+done_testing;

--- a/t/04_comment.t
+++ b/t/04_comment.t
@@ -1,10 +1,10 @@
 #!perl
 
 use strict;
-use warnings;
 use XML::FromPerl qw(xml_from_perl);
 use Test::More;
 use Tie::IxHash;
+use warnings;
 
 my $doc = xml_from_perl
     [ Foo =>

--- a/t/04_comment.t
+++ b/t/04_comment.t
@@ -1,0 +1,53 @@
+#!perl
+
+use strict;
+use warnings;
+use XML::FromPerl qw(xml_from_perl);
+use Test::More;
+use Tie::IxHash;
+
+my $doc = xml_from_perl
+    [ Foo =>
+        ['!--', 'comment'],
+        [ Bar =>
+            'Baz',
+            'Quux',
+        ],
+        ['!--', 'comment2'],
+    ];
+
+like $doc->toString,
+    qr{<Foo><!--comment--><Bar>BazQuux</Bar><!--comment2--></Foo>},
+    'comments are added';
+
+isa_ok $doc->documentElement->firstChild, 'XML::LibXML::Comment';
+
+$doc = xml_from_perl
+    [ Foo =>
+        '<!-- not a comment',
+        [ 'Bar' ],
+        'also not a comment -->',
+        [ 'Baz' ],
+        '<!--still text-->',
+    ];
+
+like $doc->toString,
+    qr{<Foo>&lt;!-- not a comment<Bar(/>|>\s*</Bar>)also not a comment --&gt;<Baz(/>|>\s*</Baz>)&lt;!--still text--&gt;</Foo>},
+    'strings with comment markers are text nodes';
+
+{
+    local $, = '#';
+    $doc = xml_from_perl [ Foo => [ '!--', 'a'..'d' ] ];
+    like $doc->toString, qr{<Foo><!--a\#b\#c\#d-->}, '$, used';
+}
+
+{
+    local $,='#';
+    $doc = xml_from_perl [ Foo => [ '!--', 'a', undef, 'b', undef, 'c' ] ];
+    like $doc->toString, qr{<!--a\#b\#c-->}, 'undefs skipped in comment';
+}
+
+$doc = xml_from_perl [ Foo => [ '!--', {attr=>42}, 'a', ] ];
+like $doc->toString, qr{<!--a-->}, 'attributes skipped in comment';
+
+done_testing;

--- a/t/05_custom_warning.t
+++ b/t/05_custom_warning.t
@@ -9,34 +9,19 @@ use Tie::IxHash;
 use warnings;   # After the `use XML::FromPerl`
                 # per https://rt.perl.org/Public/Bug/Display.html?id=128765
 
-# === Test handling of `undef` values ======================================
-
-my $doc = xml_from_perl
-    [ Foo =>
-        [ Bar =>
-            undef,
-            'Baz',
-            undef,
-            'Quux',
-        ]
-    ];
-
-like $doc->toString, qr{<Foo><Bar>BazQuux</Bar></Foo>},
-    'undef element is skipped';
-    # like(), not is(), because there's also an XML processing instruction.
-
-$doc = xml_from_perl undef;
-ok $doc, 'undef in -> document out';
-ok !defined $doc->documentElement, 'undef in -> no documentElement out';
-
-$doc = XML::LibXML::Document->new;
-my $el = xml_node_from_perl($doc, undef);
-ok !defined $el, 'No data -> undefined node';
-
-# === Test warnings for `undef` values =====================================
+BEGIN {
+    plan skip_all => 'Custom warning categories not supported before 5.014'
+        if $] lt '5.014';
+}
 
 warning_like { xml_from_perl undef } qr/document.*undefined/,
     'xml_from_perl(undef) warns by default when warnings are enabled';
+
+eval {
+    no warnings 'XML::FromPerl::undefined';
+    warning_is { xml_from_perl undef } undef,
+        'XML::FromPerl::undefined warning category works';
+};
 
 eval {
     no warnings 'XML::FromPerl';
@@ -44,9 +29,15 @@ eval {
         'XML::FromPerl warning category works';
 };
 
-$doc = XML::LibXML::Document->new;
+my $doc = XML::LibXML::Document->new;
 warning_like { xml_node_from_perl $doc, undef } qr/node.*undefined/,
     'xml_node_from_perl(undef) warns by default when warnings are enabled';
+
+eval {
+    no warnings 'XML::FromPerl::undefined';
+    warning_is { xml_node_from_perl $doc, undef } undef,
+        'XML::FromPerl::undefined warning category works in xml_node_from_perl';
+};
 
 eval {
     no warnings 'XML::FromPerl';


### PR DESCRIPTION
This PR builds on #2, and fixes #3.  It also includes a basic fix for #4.  Again, I have not updated `Changes` or the version number, but am happy to do so.

- #3: `<!--...-->` strings will now create comments instead of text nodes.
- #4: `undef` values for node text or children will now be ignored.

Thank you for considering this PR!